### PR TITLE
support absolute location workspaces

### DIFF
--- a/pkg/controllers/synceraddons/addon.go
+++ b/pkg/controllers/synceraddons/addon.go
@@ -58,7 +58,7 @@ var (
 	genericCodecs = serializer.NewCodecFactory(genericScheme)
 	genericCodec  = genericCodecs.UniversalDeserializer()
 
-	permisionFiles = []string{
+	permissionFiles = []string{
 		"manifests/kcp_clusterrolebinding.yaml",
 	}
 
@@ -260,7 +260,7 @@ func (s *syncerAddon) bindClusterRole(clusterName, addonName string, recorder ev
 			}
 			return assets.MustCreateAssetFromTemplate(name, file, config).Data, nil
 		},
-		permisionFiles...,
+		permissionFiles...,
 	)
 
 	for _, result := range results {


### PR DESCRIPTION
We need to support creating workload clusters in location workspaces directly under the root, and we may not have access to read the clusterworkspaces in the root workspace. With this PR, we allow the user to specify an absolute location (e.g., "root:my-location-workspace") or relative location as before. Currently I am checking if it is absolute by comparing it to the kcp config URL, so it's only allowing absolute locations equal to the kcp config current context or a child of that. We could change it to just check for "root" too to decide if it's relative, but I think what's here works well for our short term goals and this will all be reworked when we implement the compute service.