### PR TITLE
support multiple instances of controller on same hub

### DIFF
--- a/pkg/controllers/addonmanagement/clustermanagementaddons.go
+++ b/pkg/controllers/addonmanagement/clustermanagementaddons.go
@@ -65,7 +65,7 @@ func NewClusterManagementAddonController(
 		},
 		func(obj interface{}) bool {
 			accessor, _ := meta.Accessor(obj)
-			return strings.HasPrefix(accessor.GetName(), "kcp-syncer-")
+			return strings.HasPrefix(accessor.GetName(), helpers.GetSyncerPrefix())
 		},
 		clusterManagementAddonInformer.Informer()).
 		WithSync(c.sync).ToController("syncer-addon-controller", recorder)
@@ -159,7 +159,8 @@ func (c *clusterManagementAddonController) removeFinalizer(ctx context.Context, 
 }
 
 func (c *clusterManagementAddonController) getWorkspaceConfig(ctx context.Context, cmaddon *addonapiv1alpha1.ClusterManagementAddOn) *rest.Config {
-	workspaceId, ok := cmaddon.Annotations["kcp-workspace"]
+	a := helpers.GetWorkspaceAnnotationName()
+	workspaceId, ok := cmaddon.Annotations[a]
 	if !ok {
 		return nil
 	}

--- a/pkg/controllers/addonmanagement/managedcluster.go
+++ b/pkg/controllers/addonmanagement/managedcluster.go
@@ -94,7 +94,7 @@ func NewClusterController(
 			},
 			func(obj interface{}) bool {
 				accessor, _ := meta.Accessor(obj)
-				return strings.HasPrefix(accessor.GetName(), "kcp-syncer-")
+				return strings.HasPrefix(accessor.GetName(), helpers.GetSyncerPrefix())
 			},
 			addonInformers.Informer(),
 		).
@@ -226,7 +226,7 @@ func (c *clusterController) removeAddons(ctx context.Context, clusterName, works
 	}
 
 	for _, addon := range addons {
-		if !strings.HasPrefix(addon.Name, "kcp-syncer-") {
+		if !strings.HasPrefix(addon.Name, helpers.GetSyncerPrefix()) {
 			continue
 		}
 
@@ -312,11 +312,12 @@ func (c *clusterController) applyClusterManagementAddOn(ctx context.Context, wor
 	clusterManagementAddOnName := helpers.GetAddonName(workspaceId)
 	_, err := c.addonClient.AddonV1alpha1().ClusterManagementAddOns().Get(ctx, clusterManagementAddOnName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
+		a := helpers.GetWorkspaceAnnotationName()
 		clusterManagementAddOn := &addonapiv1alpha1.ClusterManagementAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterManagementAddOnName,
 				Annotations: map[string]string{
-					"kcp-workspace": workspaceId,
+					a: workspaceId,
 				},
 			},
 			Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{

--- a/pkg/controllers/synceraddons/addon.go
+++ b/pkg/controllers/synceraddons/addon.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -198,6 +199,14 @@ func (s *syncerAddon) signer(csr *certificatesv1.CertificateSigningRequest) []by
 	return data
 }
 
+func getSyncerImage() string {
+	syncerImage := os.Getenv("KCP_SYNCER_IMAGE")
+	if len(syncerImage) > 0 {
+		return syncerImage
+	}
+	return defaultSyncerImage
+}
+
 func (s *syncerAddon) loadManifestFromFile(file string, cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) (runtime.Object, error) {
 	manifestConfig := struct {
 		AddonName           string
@@ -212,7 +221,7 @@ func (s *syncerAddon) loadManifestFromFile(file string, cluster *clusterv1.Manag
 		Cluster:             cluster.Name,
 		LogicalCluster:      s.kcpLogicalCluster,
 		LogicalClusterLabel: strings.ReplaceAll(s.kcpLogicalCluster, ":", "_"),
-		Image:               defaultSyncerImage,
+		Image:               getSyncerImage(),
 		Namespace:           addon.Spec.InstallNamespace,
 		CertsEnabled:        s.certsEnabled,
 	}


### PR DESCRIPTION
Support an env var with the kcp instance "e.g., "kcp-stable" that will be used to differentiate between managed cluster sets intended for each instance and help prevent clustermanagementaddons for same-named workspaces from different instances from colliding.
Also support an env var to specify the syncer image.

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>