### PR TITLE
create clusterrole for syncer service account

### DIFF
--- a/pkg/controllers/synceraddons/addon.go
+++ b/pkg/controllers/synceraddons/addon.go
@@ -59,7 +59,9 @@ var (
 	genericCodecs = serializer.NewCodecFactory(genericScheme)
 	genericCodec  = genericCodecs.UniversalDeserializer()
 
+	// Created on kcp for the syncer service account
 	permissionFiles = []string{
+		"manifests/kcp_clusterrole.yaml",
 		"manifests/kcp_clusterrolebinding.yaml",
 	}
 

--- a/pkg/controllers/synceraddons/manifests/kcp_clusterrole.yaml
+++ b/pkg/controllers/synceraddons/manifests/kcp_clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .AddonName }}-{{ .Cluster }}
+rules:
+- apiGroups: ["workload.kcp.dev"]
+  resources: ["workloadclusters"]
+  resourceNames: [{{ .Cluster }}]
+  verbs: ["sync"]
+- apiGroups: ["workload.kcp.dev"]
+  resources: ["workloadclusters/status"]
+  resourceNames: [{{ .Cluster }}]
+  verbs: ["update", "patch"]
+- apiGroups: ["workload.kcp.dev"]
+  resources: ["workloadclusters"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiresource.kcp.dev"]
+  resources: ["apiresourceimports"]
+  verbs: ["get", "create", "update", "delete", "list", "watch"]

--- a/pkg/controllers/synceraddons/manifests/kcp_clusterrolebinding.yaml
+++ b/pkg/controllers/synceraddons/manifests/kcp_clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .AddonName }}-{{ .Cluster }}
 subjects:
 {{- if .CertsEnabled }}
 - kind: Group


### PR DESCRIPTION
Rather than giving the syncer cluster-admin, we should create a new cluster role with only the specific permissions it needs.
I have tested this with our redhat-acm-compute-dev account, but am unable to validate using a service account in my user workspace due to https://github.com/kcp-dev/kcp/issues/1340

If we find this set of roles is not reasonably stable, we should submit a PR to KCP making https://github.com/kcp-dev/kcp/blob/main/pkg/cliplugins/workload/plugin/sync.go#L227 consumable.

https://issues.redhat.com/browse/CMCS-160

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>